### PR TITLE
Switched to subchart structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switched from library chart to standard chart to make use of templates and local values.yaml file
+
 ## [0.1.1] - 2022-04-12
 
 ### Fixed

--- a/helm/cluster-shared/Chart.yaml
+++ b/helm/cluster-shared/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 appVersion: 0.0.1
-type: library
 name: cluster-shared
 description: A library chart of shared CAPI cluster helpers
 home: https://github.com/giantswarm/cluster-shared

--- a/helm/cluster-shared/templates/_helpers.tpl
+++ b/helm/cluster-shared/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "labels.common" -}}
+app: {{ include "name" . | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
+giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
+giantswarm.io/organization: {{ .Values.organization | quote }}
+helm.sh/chart: {{ include "chart" . | quote }}
+{{- end -}}
+
+{{/*
+Create a name stem for resource names
+When resources are created from templates by Cluster API controllers, they are given random suffixes.
+Given that Kubernetes allows 63 characters for resource names, the stem is truncated to 47 characters to leave
+room for such suffix.
+*/}}
+{{- define "resource.default.name" -}}
+{{ .Values.clusterName }}
+{{- end -}}
+
+{{- define "sshFiles" -}}
+- path: /etc/ssh/trusted-user-ca-keys.pem
+  permissions: "0600"
+  encoding: base64
+  content: {{ tpl ($.Files.Get "files/etc/ssh/trusted-user-ca-keys.pem") . | b64enc }}
+- path: /etc/ssh/sshd_config
+  permissions: "0600"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/ssh/sshd_config" | b64enc }}
+{{- end -}}
+
+{{- define "diskFiles" -}}
+- path: /opt/init-disks.sh
+  permissions: "0700"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/init-disks.sh" | b64enc }}
+{{- end -}}
+
+{{- define "kubernetesFiles" -}}
+- path: /etc/kubernetes/policies/audit-policy.yaml
+  permissions: "0600"
+  encoding: base64
+  content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
+{{- end -}}
+
+
+{{- define "sshPostKubeadmCommands" -}}
+- systemctl restart sshd
+{{- end -}}
+
+{{- define "diskPreKubeadmCommands" -}}
+- /bin/sh /opt/init-disks.sh
+{{- end -}}
+
+{{- define "sshUsers" -}}
+- name: giantswarm
+  groups: sudo
+  sudo: ALL=(ALL) NOPASSWD:ALL
+{{- end -}}
+
+{{- define "bastionIgnition" }}
+{{- tpl ($.Files.Get "files/bastion.iqn") . | b64enc}}
+{{- end -}}

--- a/helm/cluster-shared/templates/coredns.yaml
+++ b/helm/cluster-shared/templates/coredns.yaml
@@ -1,4 +1,3 @@
-{{- define "shared.coredns-adopter" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -330,5 +329,4 @@ spec:
   - kind: ConfigMap
     name: {{ include "resource.default.name" $ }}-coredns
 ---
-{{- end -}}
 {{- end -}}

--- a/helm/cluster-shared/templates/psps.yaml
+++ b/helm/cluster-shared/templates/psps.yaml
@@ -1,4 +1,3 @@
-{{- define "shared.default-psps" }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 apiVersion: v1
@@ -161,6 +160,5 @@ spec:
   - kind: ConfigMap
     name: {{ include "resource.default.name" $ }}-psps
 ---
-{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION


This PR:

- Switched from library chart to standard chart to make use of templates and local values.yaml file

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
