### PR TITLE
Fix templates to use global values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Templates are now chart-specific
+- `.Values.global` used for sharing values
+
 ## [0.2.0] - 2022-04-13
 
 ### Changed

--- a/helm/cluster-shared/ci/ci-values.yaml
+++ b/helm/cluster-shared/ci/ci-values.yaml
@@ -1,0 +1,2 @@
+global:
+  clusterName: "test"

--- a/helm/cluster-shared/templates/_helpers.tpl
+++ b/helm/cluster-shared/templates/_helpers.tpl
@@ -3,28 +3,28 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "cluster-shared.name" -}}
 {{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart" -}}
+{{- define "cluster-shared.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "labels.common" -}}
-app: {{ include "name" . | quote }}
+{{- define "cluster-shared.labels.common" -}}
+app: {{ include "cluster-shared.name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
-cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
-giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.organization | quote }}
-helm.sh/chart: {{ include "chart" . | quote }}
+cluster.x-k8s.io/cluster-name: {{ include "cluster-shared.resource.default.name" . | quote }}
+giantswarm.io/cluster: {{ include "cluster-shared.resource.default.name" . | quote }}
+giantswarm.io/organization: {{ .Values.global.organization | quote }}
+helm.sh/chart: {{ include "cluster-shared.chart" . | quote }}
 {{- end -}}
 
 {{/*
@@ -33,50 +33,6 @@ When resources are created from templates by Cluster API controllers, they are g
 Given that Kubernetes allows 63 characters for resource names, the stem is truncated to 47 characters to leave
 room for such suffix.
 */}}
-{{- define "resource.default.name" -}}
-{{ .Values.clusterName }}
-{{- end -}}
-
-{{- define "sshFiles" -}}
-- path: /etc/ssh/trusted-user-ca-keys.pem
-  permissions: "0600"
-  encoding: base64
-  content: {{ tpl ($.Files.Get "files/etc/ssh/trusted-user-ca-keys.pem") . | b64enc }}
-- path: /etc/ssh/sshd_config
-  permissions: "0600"
-  encoding: base64
-  content: {{ $.Files.Get "files/etc/ssh/sshd_config" | b64enc }}
-{{- end -}}
-
-{{- define "diskFiles" -}}
-- path: /opt/init-disks.sh
-  permissions: "0700"
-  encoding: base64
-  content: {{ $.Files.Get "files/opt/init-disks.sh" | b64enc }}
-{{- end -}}
-
-{{- define "kubernetesFiles" -}}
-- path: /etc/kubernetes/policies/audit-policy.yaml
-  permissions: "0600"
-  encoding: base64
-  content: {{ $.Files.Get "files/etc/kubernetes/policies/audit-policy.yaml" | b64enc }}
-{{- end -}}
-
-
-{{- define "sshPostKubeadmCommands" -}}
-- systemctl restart sshd
-{{- end -}}
-
-{{- define "diskPreKubeadmCommands" -}}
-- /bin/sh /opt/init-disks.sh
-{{- end -}}
-
-{{- define "sshUsers" -}}
-- name: giantswarm
-  groups: sudo
-  sudo: ALL=(ALL) NOPASSWD:ALL
-{{- end -}}
-
-{{- define "bastionIgnition" }}
-{{- tpl ($.Files.Get "files/bastion.iqn") . | b64enc}}
+{{- define "cluster-shared.resource.default.name" -}}
+{{ required "Please provide a clusterName value" .Values.global.clusterName }}
 {{- end -}}

--- a/helm/cluster-shared/templates/coredns.yaml
+++ b/helm/cluster-shared/templates/coredns.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "resource.default.name" $ }}-coredns
+  name: {{ include "cluster-shared.resource.default.name" . }}-coredns
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "labels.common" $ | nindent 4 }}
+    {{- include "cluster-shared.labels.common" . | nindent 4 }}
 data:
   coredns.yml: |
     apiVersion: v1
@@ -14,7 +14,7 @@ data:
       name: coredns
       namespace: kube-system
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -26,7 +26,7 @@ data:
       namespace: kube-system
       name: coredns
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -60,7 +60,7 @@ data:
       name: coredns-adopter
       namespace: kube-system
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     ---
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
     apiVersion: policy/v1beta1
@@ -68,7 +68,7 @@ data:
     metadata:
       name: coredns
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -108,7 +108,7 @@ data:
     metadata:
       name: coredns-psp-user
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -128,7 +128,7 @@ data:
     metadata:
       name: coredns-psp
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -147,7 +147,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     spec:
       hostNetwork: true
       privileged: false
@@ -182,7 +182,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     rules:
     - apiGroups: ["*"]
       resources: ["*"]
@@ -214,7 +214,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: coredns-adopter
@@ -229,7 +229,7 @@ data:
     metadata:
       name: coredns-adopter-rbac
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: coredns-adopter
@@ -245,7 +245,7 @@ data:
       name: coredns-adopter
       namespace: kube-system
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
       annotations:
         kubernetes.io/description: |
           Runs at cluster creation to label and annotate default, kubeadm installed CoreDNS
@@ -256,7 +256,7 @@ data:
         metadata:
           name: coredns-adopter
           labels:
-            {{- include "labels.common" $ | nindent 12 }}
+            {{- include "cluster-shared.labels.common" . | nindent 12 }}
           annotations:
             kubernetes.io/description: |
               Runs at cluster creation to label and annotate default, kubeadm installed CoreDNS
@@ -317,16 +317,16 @@ data:
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
-  name: {{ include "resource.default.name" $ }}-coredns
+  name: {{ include "cluster-shared.resource.default.name" . }}-coredns
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "labels.common" $ | nindent 4 }}
+    {{- include "cluster-shared.labels.common" . | nindent 4 }}
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "labels.common" $ | nindent 6 }}
+      {{- include "cluster-shared.labels.common" . | nindent 6 }}
   resources:
   - kind: ConfigMap
-    name: {{ include "resource.default.name" $ }}-coredns
+    name: {{ include "cluster-shared.resource.default.name" . }}-coredns
 ---
 {{- end -}}

--- a/helm/cluster-shared/templates/psps.yaml
+++ b/helm/cluster-shared/templates/psps.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "resource.default.name" $ }}-psps
+  name: {{ include "cluster-shared.resource.default.name" . }}-psps
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "labels.common" $ | nindent 4 }}
+    {{- include "cluster-shared.labels.common" . | nindent 4 }}
 data:
   standard_psps.yml: |
     apiVersion: policy/v1beta1
@@ -14,7 +14,7 @@ data:
     metadata:
       name: privileged
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
       annotations:
         seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     spec:
@@ -44,7 +44,7 @@ data:
     metadata:
       name: restricted
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     spec:
       privileged: false
       allowPrivilegeEscalation: false
@@ -79,7 +79,7 @@ data:
     metadata:
       name: privileged-psp-user
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     rules:
     - apiGroups:
       - extensions
@@ -95,7 +95,7 @@ data:
     metadata:
       name: privileged-psp-users
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: kube-proxy
@@ -118,7 +118,7 @@ data:
     metadata:
       name: restricted-psp-user
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     rules:
     - apiGroups:
       - extensions
@@ -134,7 +134,7 @@ data:
     metadata:
       name: restricted-psp-users
       labels:
-        {{- include "labels.common" $ | nindent 8 }}
+        {{- include "cluster-shared.labels.common" . | nindent 8 }}
     subjects:
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -148,17 +148,17 @@ data:
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
-  name: {{ include "resource.default.name" $ }}-psps
+  name: {{ include "cluster-shared.resource.default.name" . }}-psps
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "labels.common" $ | nindent 4 }}
+    {{- include "cluster-shared.labels.common" . | nindent 4 }}
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "labels.common" $ | nindent 6 }}
+      {{- include "cluster-shared.labels.common" . | nindent 6 }}
   resources:
   - kind: ConfigMap
-    name: {{ include "resource.default.name" $ }}-psps
+    name: {{ include "cluster-shared.resource.default.name" . }}-psps
 ---
 {{- end -}}
 {{- end -}}

--- a/helm/cluster-shared/values.yaml
+++ b/helm/cluster-shared/values.yaml
@@ -1,4 +1,5 @@
 name: cluster-shared
+clusterName: ""
 
 project:
   branch: "[[ .Branch ]]"
@@ -10,3 +11,6 @@ kubectlImage:
   registry: quay.io
   name: giantswarm/kubectl
   tag: 1.23.5
+
+global:
+  clusterName: ""


### PR DESCRIPTION


This PR:

- Templates are now chart-specific
- `.Values.global` used for sharing values

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
