### PR TITLE
Switch back to library chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reverted back to library chart to make use of parent chart templates
+- Defaulting of expected values handled in templates (as library charts don't have values.yaml)
+
 ## [0.2.1] - 2022-04-13
 
 ### Fixed

--- a/helm/cluster-shared/Chart.yaml
+++ b/helm/cluster-shared/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 appVersion: 0.0.1
+type: library
 name: cluster-shared
 description: A library chart of shared CAPI cluster helpers
 home: https://github.com/giantswarm/cluster-shared

--- a/helm/cluster-shared/ci/ci-values.yaml
+++ b/helm/cluster-shared/ci/ci-values.yaml
@@ -1,2 +1,0 @@
-global:
-  clusterName: "test"

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -1,11 +1,12 @@
+{{ define "coredns" }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cluster-shared.resource.default.name" . }}-coredns
+  name: {{ include "resource.default.name" . }}-coredns
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cluster-shared.labels.common" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   coredns.yml: |
     apiVersion: v1
@@ -14,7 +15,7 @@ data:
       name: coredns
       namespace: kube-system
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -26,7 +27,7 @@ data:
       namespace: kube-system
       name: coredns
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -60,7 +61,7 @@ data:
       name: coredns-adopter
       namespace: kube-system
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     ---
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
     apiVersion: policy/v1beta1
@@ -68,7 +69,7 @@ data:
     metadata:
       name: coredns
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -108,7 +109,7 @@ data:
     metadata:
       name: coredns-psp-user
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -128,7 +129,7 @@ data:
     metadata:
       name: coredns-psp
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
         app.kubernetes.io/managed-by: Helm
       annotations:
         meta.helm.sh/release-name: coredns
@@ -147,7 +148,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     spec:
       hostNetwork: true
       privileged: false
@@ -182,7 +183,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     rules:
     - apiGroups: ["*"]
       resources: ["*"]
@@ -214,7 +215,7 @@ data:
     metadata:
       name: coredns-adopter
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: coredns-adopter
@@ -229,7 +230,7 @@ data:
     metadata:
       name: coredns-adopter-rbac
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: coredns-adopter
@@ -245,7 +246,7 @@ data:
       name: coredns-adopter
       namespace: kube-system
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
       annotations:
         kubernetes.io/description: |
           Runs at cluster creation to label and annotate default, kubeadm installed CoreDNS
@@ -256,7 +257,7 @@ data:
         metadata:
           name: coredns-adopter
           labels:
-            {{- include "cluster-shared.labels.common" . | nindent 12 }}
+            {{- include "labels.common" . | nindent 12 }}
           annotations:
             kubernetes.io/description: |
               Runs at cluster creation to label and annotate default, kubeadm installed CoreDNS
@@ -313,20 +314,21 @@ data:
               kubectl -n kube-system delete deployment coredns
               kubectl apply -f /tmp/dep.yaml
 ---
-{{- if .Values.includeClusterResourceSet }}
+{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
-  name: {{ include "cluster-shared.resource.default.name" . }}-coredns
+  name: {{ include "resource.default.name" . }}-coredns
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cluster-shared.labels.common" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "cluster-shared.labels.common" . | nindent 6 }}
+      {{- include "labels.common" . | nindent 6 }}
   resources:
   - kind: ConfigMap
-    name: {{ include "cluster-shared.resource.default.name" . }}-coredns
+    name: {{ include "resource.default.name" . }}-coredns
 ---
 {{- end -}}
+{{ end }}

--- a/helm/cluster-shared/templates/_helpers.tpl
+++ b/helm/cluster-shared/templates/_helpers.tpl
@@ -23,7 +23,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "cluster-shared.resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "cluster-shared.resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.global.organization | quote }}
 helm.sh/chart: {{ include "cluster-shared.chart" . | quote }}
 {{- end -}}
 
@@ -34,5 +33,5 @@ Given that Kubernetes allows 63 characters for resource names, the stem is trunc
 room for such suffix.
 */}}
 {{- define "cluster-shared.resource.default.name" -}}
-{{ required "Please provide a clusterName value" .Values.global.clusterName }}
+{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/cluster-shared/templates/_helpers.tpl
+++ b/helm/cluster-shared/templates/_helpers.tpl
@@ -1,37 +1,15 @@
-{{/* vim: set filetype=mustache: */}}
 
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "cluster-shared.name" -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "cluster-shared.clusterresourceset.enabled" -}}
+{{ .Values.includeClusterResourceSet | default true }}
+{{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "cluster-shared.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "cluster-shared.labels.common" -}}
-app: {{ include "cluster-shared.name" . | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.Version | quote }}
-cluster.x-k8s.io/cluster-name: {{ include "cluster-shared.resource.default.name" . | quote }}
-giantswarm.io/cluster: {{ include "cluster-shared.resource.default.name" . | quote }}
-helm.sh/chart: {{ include "cluster-shared.chart" . | quote }}
-{{- end -}}
-
-{{/*
-Create a name stem for resource names
-When resources are created from templates by Cluster API controllers, they are given random suffixes.
-Given that Kubernetes allows 63 characters for resource names, the stem is truncated to 47 characters to leave
-room for such suffix.
-*/}}
-{{- define "cluster-shared.resource.default.name" -}}
-{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "cluster-shared.kubectl-image" -}}
+{{- $kubectlRegistry := "quay.io" -}}
+{{- $kubectlName := "giantswarm/kubectl" -}}
+{{- $kubectlTag := "1.23.5" -}}
+{{- if not .Values.kubectlImage }}
+quay.io/giantswarm/kubectl:1.23.5
+{{- else }}
+{{ .Values.kubectlImage.registry | default $kubectlRegistry }}/{{ .Values.kubectlImage.name | default $kubectlName }}:{{ .Values.kubectlImage.tag | default $kubectlTag}}
+{{- end }}
+{{- end }}

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -1,12 +1,13 @@
+{{ define "psps" }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cluster-shared.resource.default.name" . }}-psps
+  name: {{ include "resource.default.name" . }}-psps
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cluster-shared.labels.common" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   standard_psps.yml: |
     apiVersion: policy/v1beta1
@@ -14,7 +15,7 @@ data:
     metadata:
       name: privileged
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
       annotations:
         seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     spec:
@@ -44,7 +45,7 @@ data:
     metadata:
       name: restricted
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     spec:
       privileged: false
       allowPrivilegeEscalation: false
@@ -79,7 +80,7 @@ data:
     metadata:
       name: privileged-psp-user
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     rules:
     - apiGroups:
       - extensions
@@ -95,7 +96,7 @@ data:
     metadata:
       name: privileged-psp-users
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     subjects:
     - kind: ServiceAccount
       name: kube-proxy
@@ -118,7 +119,7 @@ data:
     metadata:
       name: restricted-psp-user
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     rules:
     - apiGroups:
       - extensions
@@ -134,7 +135,7 @@ data:
     metadata:
       name: restricted-psp-users
       labels:
-        {{- include "cluster-shared.labels.common" . | nindent 8 }}
+        {{- include "labels.common" . | nindent 8 }}
     subjects:
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -144,21 +145,22 @@ data:
       kind: ClusterRole
       name: restricted-psp-user
 ---
-{{- if .Values.includeClusterResourceSet }}
+{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
-  name: {{ include "cluster-shared.resource.default.name" . }}-psps
+  name: {{ include "resource.default.name" . }}-psps
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "cluster-shared.labels.common" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "cluster-shared.labels.common" . | nindent 6 }}
+      {{- include "labels.common" . | nindent 6 }}
   resources:
   - kind: ConfigMap
-    name: {{ include "cluster-shared.resource.default.name" . }}-psps
+    name: {{ include "resource.default.name" . }}-psps
 ---
 {{- end -}}
 {{- end -}}
+{{ end }}

--- a/helm/cluster-shared/values.yaml
+++ b/helm/cluster-shared/values.yaml
@@ -11,6 +11,3 @@ kubectlImage:
   registry: quay.io
   name: giantswarm/kubectl
   tag: 1.23.5
-
-global:
-  clusterName: ""

--- a/helm/cluster-shared/values.yaml
+++ b/helm/cluster-shared/values.yaml
@@ -1,13 +1,1 @@
-name: cluster-shared
-clusterName: ""
-
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"
-
-includeClusterResourceSet: true
-
-kubectlImage:
-  registry: quay.io
-  name: giantswarm/kubectl
-  tag: 1.23.5
+# This isn't used by library charts


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Reverted back to library chart to make use of parent chart templates
- Defaulting of expected values handled in templates (as library charts don't have values.yaml)

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
