### PR TITLE
Switched to using selector labels for clusterSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Used `labels.selector` for the `clusterSelector` to ensure immutability across versions
+
 ## [0.3.0] - 2022-04-13
 
 ### Changed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -325,7 +325,7 @@ metadata:
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "labels.common" . | nindent 6 }}
+      {{- include "labels.selector" . | nindent 6 }}
   resources:
   - kind: ConfigMap
     name: {{ include "resource.default.name" . }}-coredns

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -156,7 +156,7 @@ metadata:
 spec:
   clusterSelector:
     matchLabels:
-      {{- include "labels.common" . | nindent 6 }}
+      {{- include "labels.selector" . | nindent 6 }}
   resources:
   - kind: ConfigMap
     name: {{ include "resource.default.name" . }}-psps


### PR DESCRIPTION
Breaking change as parent chart needs to provide the `labels.selector` helper