### PR TITLE
improve defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `configMap` for Workload Clusters will only be generated if the Management Cluster has the `ClusterResourceSet` capability.
+
+### Fixed
+
+- if `kubectl` image isn't specified, a default image will be used
+
 ## [0.5.7] - 2022-06-29
 
 ### Fixed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -1,4 +1,6 @@
 {{ define "coredns" }}
+{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet" }}
+{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -63,7 +65,6 @@ data:
       labels:
         {{- include "labels.common" . | nindent 8 }}
     ---
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
     apiVersion: policy/v1beta1
     kind: PodSecurityPolicy
     metadata:
@@ -177,7 +178,6 @@ data:
       hostIPC: false
       readOnlyRootFilesystem: false
     ---
-{{- end }}
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -259,7 +259,7 @@ data:
           hostNetwork: true # No need to wait for CNI to be ready
           containers:
           - name: kubectl
-            image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+            image: "{{ include "cluster-shared.kubectl-image" . }}"
             command:
             - bash
             - -c
@@ -313,7 +313,6 @@ data:
 
               echo "CoreDNS adoption complete!"
 ---
-{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -329,5 +328,6 @@ spec:
   - kind: ConfigMap
     name: {{ include "resource.default.name" . }}-coredns
 ---
+{{- end -}}
 {{- end -}}
 {{ end }}

--- a/helm/cluster-shared/templates/_helpers.tpl
+++ b/helm/cluster-shared/templates/_helpers.tpl
@@ -4,12 +4,8 @@
 {{- end }}
 
 {{- define "cluster-shared.kubectl-image" -}}
-{{- $kubectlRegistry := "quay.io" -}}
-{{- $kubectlName := "giantswarm/kubectl" -}}
-{{- $kubectlTag := "1.24.1" -}}
-{{- if not .Values.kubectlImage }}
-quay.io/giantswarm/kubectl:1.23.5
-{{- else }}
-{{ .Values.kubectlImage.registry | default $kubectlRegistry }}/{{ .Values.kubectlImage.name | default $kubectlName }}:{{ .Values.kubectlImage.tag | default $kubectlTag}}
-{{- end }}
+{{- $kubectlImageRegistry := "quay.io" -}}
+{{- $kubectlImageName := "giantswarm/kubectl" -}}
+{{- $kubectlImageTag := "1.24.1" -}}
+{{ .Values.kubectlImage.registry | default $kubectlImageRegistry }}/{{ .Values.kubectlImage.name | default $kubectlImageName }}:{{ .Values.kubectlImage.tag | default $kubectlImageTag}}
 {{- end }}

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -1,5 +1,6 @@
 {{ define "psps" }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet" }}
+{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -145,7 +146,6 @@ data:
       kind: ClusterRole
       name: restricted-psp-user
 ---
-{{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:


### PR DESCRIPTION
generate chart only if ClusterResourceSet exists
* only generate the configmap for WCs if CRD ClusterResourceSet exists
  on the management cluster
* fix broken defaulting for kubectl image

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
