### PR TITLE
kube-dns service wont be recreated on new clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `kube-dns` service will not be generated anymore. This change was only required for already existing clusters with customer workload.
+
 ## [0.6.2] - 2022-09-22
 
 ### Changed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -298,14 +298,8 @@ data:
                 | jq '.spec.selector."k8s-app"="coredns"' \
                 | jq 'del(.status, .metadata.uid, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp)' \
                 | tee /tmp/svc.yaml
-              kubectl -n kube-system get service kube-dns -o json \
-                | jq '.spec.selector."k8s-app"="coredns"' \
-                | jq '(. | .spec.ports[] | select(.targetPort==53)).targetPort |= 1053' \
-                | jq 'del(.status, .metadata.uid, .metadata.resourceVersion, .metadata.generation, .metadata.creationTimestamp, .spec.clusterIP, .spec.clusterIPs, .metadata.labels, .metadata.annotations)' \
-                | tee /tmp/svc-kubedns.yaml
               kubectl -n kube-system delete service kube-dns
               kubectl apply -f /tmp/svc.yaml
-              kubectl apply -f /tmp/svc-kubedns.yaml
               echo "Finished updating coredns service"
 
               echo "Updating coredns deployment..."


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
