### PR TITLE
coredns-adopter - poll apiserver to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Have coredns-adopter poll the apiserver until it's ready before starting
+
 ## [0.6.3] - 2022-10-19
 
 ### Changed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -198,6 +198,10 @@ data:
     - apiGroups: [""]
       resources: ["services"]
       verbs: ["create"]
+    - apiGroups: [""]
+      resources: ["services"]
+      resourceNames: ["kubernetes"]
+      verbs: ["get"]
     ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/1588

This PR:

- adds an initContainer to the coredns-adopter to poll for the apiserver being ready and accessible before starting with the adoption

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
