### PR TITLE
disable host networking and remove init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable host networking and remove init container
+
 ## [0.6.4] - 2022-11-08
 
 ### Fixed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -261,19 +261,7 @@ data:
           serviceAccountName: coredns-adopter
           tolerations:
           - operator: Exists
-          hostNetwork: true # No need to wait for CNI to be ready
-          initContainers:
-          - name: wait-for-apiserver
-            image: "{{ include "cluster-shared.kubectl-image" . }}"
-            command:
-            - bash
-            - -c
-            - |
-              set -e
-              while [[ "$(kubectl -n default get service kubernetes -o name 2>/dev/null)" != "service/kubernetes" ]]; do
-                echo "Waiting for API server to be ready..."
-                sleep 10
-              done
+          hostNetwork: false # No need to wait for CNI to be ready
           containers:
           - name: kubectl
             image: "{{ include "cluster-shared.kubectl-image" . }}"

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -261,7 +261,7 @@ data:
           serviceAccountName: coredns-adopter
           tolerations:
           - operator: Exists
-          hostNetwork: false # No need to wait for CNI to be ready
+          hostNetwork: false 
           containers:
           - name: kubectl
             image: "{{ include "cluster-shared.kubectl-image" . }}"


### PR DESCRIPTION
This PR:

- Removes the init container in favour of disabling host networking.

Cilium takes some time to get ready and, regardless, this fails until it is.
The code states `echo "Waiting for API server to be ready..."` but we can't find the reason why this was put in place.

Opening this for discussion, are we ok with this PR or not?

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
