### PR TITLE
Allow usage of Seccomp Profiles on the restricted PSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Annotate the `restricted` PSP to allow the use of Seccomp Profiles.
+
 ## [0.6.4] - 2022-11-08
 
 ### Fixed

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -47,6 +47,8 @@ data:
       name: restricted
       labels:
         {{- include "labels.common" . | nindent 8 }}
+      annotations:
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     spec:
       privileged: false
       allowPrivilegeEscalation: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27011