### PR TITLE
kyverno compliance for coredns-adopter job 

### DIFF
--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -250,8 +250,10 @@ data:
         - resources:
             kinds:
             - Job
+            - Pod
             names:
             - coredns-adopter
+            - coredns-adopter-*
             namespaces:
             - kube-system
     ---

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -256,15 +256,22 @@ data:
               Runs at cluster creation to label and annotate default, kubeadm installed CoreDNS
               resources so they can be managed by Helm and replaced with our managed app.
         spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
           activeDeadlineSeconds: 1800 # 30 minutes
           restartPolicy: Never
           serviceAccountName: coredns-adopter
           tolerations:
           - operator: Exists
-          hostNetwork: true # No need to wait for CNI to be ready
           initContainers:
           - name: wait-for-apiserver
             image: "{{ include "cluster-shared.kubectl-image" . }}"
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              allowPrivilegeEscalation: false
             command:
             - bash
             - -c
@@ -277,6 +284,10 @@ data:
           containers:
           - name: kubectl
             image: "{{ include "cluster-shared.kubectl-image" . }}"
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              allowPrivilegeEscalation: false
             command:
             - bash
             - -c

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -265,6 +265,7 @@ data:
           serviceAccountName: coredns-adopter
           tolerations:
           - operator: Exists
+          hostNetwork: true # No need to wait for CNI to be ready
           initContainers:
           - name: wait-for-apiserver
             image: "{{ include "cluster-shared.kubectl-image" . }}"

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -233,6 +233,28 @@ data:
       name: system:coredns
       apiGroup: rbac.authorization.k8s.io
     ---
+    apiVersion: kyverno.io/v1
+    kind: PolicyException
+    metadata:
+      name: coredns-adopter-exception
+      namespace: kube-system
+      labels:
+        {{- include "labels.common" . | nindent 4 }}
+    spec:
+      exceptions:
+      - policyName: disallow-host-namespaces
+        ruleNames:
+        - autogen-host-namespaces
+      match:
+        any:
+        - resources:
+            kinds:
+            - Job
+            names:
+            - coredns-adopter
+            namespaces:
+            - kube-system
+    ---
     apiVersion: batch/v1
     kind: Job
     metadata:

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -244,6 +244,7 @@ data:
       exceptions:
       - policyName: disallow-host-namespaces
         ruleNames:
+        - host-namespaces
         - autogen-host-namespaces
       match:
         any:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->
Towards:

- https://github.com/giantswarm/roadmap/issues/3741
- https://github.com/giantswarm/giantswarm/issues/31706

This PR:

- changes securityContext
- disables hostNetwork
    So that coredns-adopter job complies with kyverno policies

### Testing

Description on how cluster-shared can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-shared installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
