### PR TITLE
Update ClusterResourceSet API version to v1beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update ClusterResourceSet API version from `v1beta1` to `v1beta2` and support both versions in capability checks.
+
 ## [0.7.1] - 2024-05-29
 
 ### Fixed

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -1,5 +1,5 @@
 {{ define "coredns" }}
-{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet" }}
+{{- if or (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet") (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet") }}
 {{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 ---
 apiVersion: v1
@@ -336,7 +336,7 @@ data:
 
               echo "CoreDNS adoption complete!"
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: {{ include "resource.default.name" . }}-coredns

--- a/helm/cluster-shared/templates/_coredns.tpl
+++ b/helm/cluster-shared/templates/_coredns.tpl
@@ -1,5 +1,5 @@
 {{ define "coredns" }}
-{{- if or (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet") (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet") }}
+{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet" }}
 {{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 ---
 apiVersion: v1

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -1,5 +1,5 @@
 {{ define "psps" }}
-{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet" }}
+{{- if or (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet") (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet") }}
 {{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 ---
@@ -149,7 +149,7 @@ data:
       kind: ClusterRole
       name: restricted-psp-user
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: {{ include "resource.default.name" . }}-psps
@@ -246,7 +246,7 @@ data:
       kind: ClusterRole
       name: privileged-psp-user
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: {{ include "resource.default.name" . }}-psps-allow-all

--- a/helm/cluster-shared/templates/_psps.tpl
+++ b/helm/cluster-shared/templates/_psps.tpl
@@ -1,5 +1,5 @@
 {{ define "psps" }}
-{{- if or (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta1/ClusterResourceSet") (.Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet") }}
+{{- if .Capabilities.APIVersions.Has "addons.cluster.x-k8s.io/v1beta2/ClusterResourceSet" }}
 {{- if eq (include "cluster-shared.clusterresourceset.enabled" .) "true" }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 ---


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36124

The MC now serves ClusterResourceSet at `v1beta2` only. The capability check was looking for `v1beta1`, causing the coredns-adopter ClusterResourceSet to never render. This broke coredns adoption on EKS clusters — the existing EKS coredns Service holds the cluster DNS IP, and the Giant Swarm coredns HelmRelease fails with `failed to allocate IP: provided IP is already allocated`.